### PR TITLE
Run this every hour

### DIFF
--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -2,8 +2,7 @@ name: Update source images
 
 on:
   schedule:
-    - cron: '0 6 * * *'
-  pull_request: ~
+    - cron: '0 */1 * * *'
   push:
     branches:
       - master


### PR DESCRIPTION
FYI @jderusse 

Make sure not to run on PRs but run on every hour and on pushes to master. 

Github pages uses their CDN so images are cached for about 10 minites. The script will aslo not update the source if there are no changes. 